### PR TITLE
A few updates to popup.js

### DIFF
--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -1,7 +1,8 @@
 /*global  ChromeAudioEQ,
           chrome,
           icon,
-          console
+          console,
+					CONST
                           */
 'use strict';
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,13 +1,10 @@
-/**
- * I need to clean this mess...
- */
 /*global  window,
           document,
-          ChromeAudioEQ,  
+          ChromeAudioEQ,
           chrome,
           CONST,
           chart,
-          console, 
+          console,
           modal,
           sliders,
           presets
@@ -37,10 +34,12 @@ var init = function(prs) {
       return false;
     }
 
+    function setAllEqSliders () {
+      for (var i = 0; i < eq.length; i++)
+        setValue('ch-eq-slider-' + i, eq[i].gain);
+    }
+
     function onchange(evt) {
-      // Unclear what 'this' is. I could tell jshint to ignore,
-      // but events pass themselves in as first callback arg
-      // 'evt.target' is same object as 'this' and easier to understand 
       console.log('onchange');
       var slider = evt.target.getAttribute('eq');
       if (slider === 'master') {
@@ -63,16 +62,8 @@ var init = function(prs) {
           }
         }
 
-        setValue('ch-eq-slider-1', eq[1].gain);
-        setValue('ch-eq-slider-2', eq[2].gain);
-        setValue('ch-eq-slider-3', eq[3].gain);
-        setValue('ch-eq-slider-4', eq[4].gain);
-        setValue('ch-eq-slider-5', eq[5].gain);
-        setValue('ch-eq-slider-6', eq[6].gain);
-        setValue('ch-eq-slider-7', eq[7].gain);
-        setValue('ch-eq-slider-8', eq[8].gain);
-        setValue('ch-eq-slider-9', eq[9].gain);
-        setValue('ch-eq-slider-10', eq[10].gain);
+        setAllEqSliders();
+
         chart.prepareChart(eq);
       }
 
@@ -80,8 +71,6 @@ var init = function(prs) {
     }
 
 	try {
-		var canvas, context, inputs;
-
 		var propagateData = function() {
 			//send message
 			try {
@@ -100,14 +89,12 @@ var init = function(prs) {
 					error : e
 				});
 			}
-
 		};
 
-		inputs = document.querySelectorAll('input[type="range"]');
+		var inputs = document.querySelectorAll('input[type="range"]');
 		for (var i = 0; i < inputs.length; i++) {
 			inputs[i].onchange = onchange;
 			inputs[i].oninput = onchange;
-
 		}
 
 		//TODO: dont repeat yor self!
@@ -119,17 +106,8 @@ var init = function(prs) {
 					eq[i].gain = 1;
 				}
 			}
-			setValue('ch-eq-slider-0', eq[0].gain);
-			setValue('ch-eq-slider-1', eq[1].gain);
-			setValue('ch-eq-slider-2', eq[2].gain);
-			setValue('ch-eq-slider-3', eq[3].gain);
-			setValue('ch-eq-slider-4', eq[4].gain);
-			setValue('ch-eq-slider-5', eq[5].gain);
-			setValue('ch-eq-slider-6', eq[6].gain);
-			setValue('ch-eq-slider-7', eq[7].gain);
-			setValue('ch-eq-slider-8', eq[8].gain);
-			setValue('ch-eq-slider-9', eq[9].gain);
-			setValue('ch-eq-slider-10', eq[10].gain);
+
+      setAllEqSliders();
 
 			// When user presses reset, change it back to default value (stereo)
 			config.mono = false;
@@ -213,17 +191,9 @@ var init = function(prs) {
 				for (var i = 0; i < 10; i++) {
 					eq[i + 1].gain = selected.gains[i];
 				}
-				setValue('ch-eq-slider-0', eq[0].gain);
-				setValue('ch-eq-slider-1', eq[1].gain);
-				setValue('ch-eq-slider-2', eq[2].gain);
-				setValue('ch-eq-slider-3', eq[3].gain);
-				setValue('ch-eq-slider-4', eq[4].gain);
-				setValue('ch-eq-slider-5', eq[5].gain);
-				setValue('ch-eq-slider-6', eq[6].gain);
-				setValue('ch-eq-slider-7', eq[7].gain);
-				setValue('ch-eq-slider-8', eq[8].gain);
-				setValue('ch-eq-slider-9', eq[9].gain);
-				setValue('ch-eq-slider-10', eq[10].gain);
+
+        setAllEqSliders();
+
 				chart.prepareChart(eq);
 				propagateData();
 
@@ -231,16 +201,8 @@ var init = function(prs) {
 			switch (ev.target.value) {
 			case 'action::save':
 				modal.confirm('Do you want to save "' + selected.name + '" preset?', function() {
-					selected.gains[0] = getValue('ch-eq-slider-1');
-					selected.gains[1] = getValue('ch-eq-slider-2');
-					selected.gains[2] = getValue('ch-eq-slider-3');
-					selected.gains[3] = getValue('ch-eq-slider-4');
-					selected.gains[4] = getValue('ch-eq-slider-5');
-					selected.gains[5] = getValue('ch-eq-slider-6');
-					selected.gains[6] = getValue('ch-eq-slider-7');
-					selected.gains[7] = getValue('ch-eq-slider-8');
-					selected.gains[8] = getValue('ch-eq-slider-9');
-					selected.gains[9] = getValue('ch-eq-slider-10');
+          for (var i = 0; i < selected.gains.length; i++)
+            selected.gains[i] = getValue('ch-eq-slider-' + (i + 1))
 					console.log('action::save', selected);
 					presets.setPreset(selected);
 					chrome.storage.sync.set({
@@ -315,17 +277,7 @@ var init = function(prs) {
 					action : 'get'
 				}, function(response) {
 					eq = response.eq;
-					setValue('ch-eq-slider-0', eq[0].gain);
-					setValue('ch-eq-slider-1', eq[1].gain);
-					setValue('ch-eq-slider-2', eq[2].gain);
-					setValue('ch-eq-slider-3', eq[3].gain);
-					setValue('ch-eq-slider-4', eq[4].gain);
-					setValue('ch-eq-slider-5', eq[5].gain);
-					setValue('ch-eq-slider-6', eq[6].gain);
-					setValue('ch-eq-slider-7', eq[7].gain);
-					setValue('ch-eq-slider-8', eq[8].gain);
-					setValue('ch-eq-slider-9', eq[9].gain);
-					setValue('ch-eq-slider-10', eq[10].gain);
+					setAllEqSliders();
 
 					config = response.config;
 					// CUSTOM: make sure toggle is checked

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -70,10 +70,8 @@ var init = function(prs) {
       propagateData();
     }
 
-	try {
 		var propagateData = function() {
 			//send message
-			try {
 				chrome.runtime.sendMessage({
 					action : 'set',
 					eq : eq,
@@ -81,14 +79,6 @@ var init = function(prs) {
 					selected : presets.getSelected(),
 					version : version
 				});
-			} catch(e) {
-				//	throw e;
-				chrome.runtime.sendMessage({
-					action : 'error',
-					source : 'popup.js',
-					error : e
-				});
-			}
 		};
 
 		var inputs = document.querySelectorAll('input[type="range"]');
@@ -268,7 +258,6 @@ var init = function(prs) {
 		};
 
 		//intialization
-		try {
 			chart.prepareChart(eq);
 			sliders.prepareSliders(eq);
 
@@ -295,26 +284,6 @@ var init = function(prs) {
 
 				});
 			}
-
-		} catch(e) {
-			//	throw e;
-			chrome.runtime.sendMessage({
-				action : 'error',
-				source : 'popup.js',
-				error : e
-			});
-			// Psssst! Dont tell anyone :)
-			throw e;
-		}
-	} catch(e) {
-		//	throw e;
-		chrome.runtime.sendMessage({
-			action : 'error',
-			source : 'popup.js',
-			error : e
-		});
-		throw e;
-	}
 };
 
 //LOAD
@@ -348,3 +317,12 @@ window.addEventListener("load", function() {
 
 	}
 });
+
+// currently unsused
+function forwardErrToBackground(e){
+  chrome.runtime.sendMessage({
+    action : 'error',
+    source : 'popup.js',
+    error : e
+  });
+}

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -229,6 +229,7 @@ var init = function(prs) {
 		default:
 			var val = (ev.target.value).split('::');
 			presets.setSelected(val[2]);
+      selected = presets.getSelected();
 			chrome.storage.local.set({
 				selected : selected.name
 			});

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -30,6 +30,15 @@ var init = function(prs) {
       setValue('ch-eq-slider-' + i, eq[i].gain);
   }
 
+  function getEqIndex(f) {
+    for (var i = 0; i < eq.length; i++) {
+      if (eq[i].f && eq[i].f + '' === f) {
+        return i;
+      }
+    }
+    return false;
+  }
+
   function propagateData () {
 		//send message
 		chrome.runtime.sendMessage({
@@ -63,7 +72,13 @@ var init = function(prs) {
       eq[0].gain = getValue('ch-eq-slider-0');
     } else {
       //eq settings
-      var index = evt.target.id.match(/\d+/)[0]; // matches numeric part of id
+      // TODO  match(/\d/) is always the same result as getEqIndex()
+      //        but for some reason causes bug. getEqIndex takes many more
+      //        CPU cycles and touches the DOM. Bug is probably elsewhere
+      //        and conveniently hidden by the delay.
+      // var index = evt.target.id.match(/\d+/)[0];
+      var index = getEqIndex(slider);
+
       var diff = evt.target.value - eq[index].gain;
       eq[index].gain = evt.target.value;
       if (config.snap) snapSliders(index, diff);

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -16,274 +16,271 @@ var init = function(prs) {
     , version = CONST.VERSION
     , config = CONST.CONFIG;
 
-    // pulled  all function defs out of the try/catch
-    function getValue(id) {
-      return document.getElementById(id).value;
-    }
+  // pulled  all function defs out of the try/catch
+  function getValue(id) {
+    return document.getElementById(id).value;
+  }
 
-    function setValue(id, val) {
-      document.getElementById(id).value = val;
-    }
+  function setValue(id, val) {
+    document.getElementById(id).value = val;
+  }
 
-    function getEqIndex(f) {
-      for (var l = eq.length, i = 0; i < l; i++) {
-        if (eq[i].f && eq[i].f + '' === f) {
-          return i;
-        }
+  function getEqIndex(f) {
+    for (var l = eq.length, i = 0; i < l; i++) {
+      if (eq[i].f && eq[i].f + '' === f) {
+        return i;
       }
-      return false;
     }
+    return false;
+  }
 
-    function setAllEqSliders () {
-      for (var i = 0; i < eq.length; i++)
-        setValue('ch-eq-slider-' + i, eq[i].gain);
-    }
+  function setAllEqSliders () {
+    for (var i = 0; i < eq.length; i++)
+      setValue('ch-eq-slider-' + i, eq[i].gain);
+  }
 
-    function onchange(evt) {
-      console.log('onchange');
-      var slider = evt.target.getAttribute('eq');
-      if (slider === 'master') {
-        //master volume change
-        eq[0].gain = getValue('ch-eq-slider-0');
-      } else {
-        //eq settings change
-        var index = getEqIndex(slider);
-        var diff = evt.target.value - eq[index].gain;
-        eq[index].gain = evt.target.value;
-        if (config.snap) {
-          for (var i = 1; i < 10; i++) {
-            diff = diff / 2;
-            if (eq[index - i] && eq[index - i].f) {
-              eq[index - i].gain = parseFloat(eq[index - i].gain, 10) + diff;
-            }
-            if (eq[index + i] && eq[index + i].f) {
-              eq[index + i].gain = parseFloat(eq[index + i].gain, 10) + diff;
-            }
+  function onchange(evt) {
+    console.log('onchange');
+    var slider = evt.target.getAttribute('eq');
+    if (slider === 'master') {
+      //master volume change
+      eq[0].gain = getValue('ch-eq-slider-0');
+    } else {
+      //eq settings change
+      var index = getEqIndex(slider);
+      var diff = evt.target.value - eq[index].gain;
+      eq[index].gain = evt.target.value;
+      if (config.snap) {
+        for (var i = 1; i < 10; i++) {
+          diff = diff / 2;
+          if (eq[index - i] && eq[index - i].f) {
+            eq[index - i].gain = parseFloat(eq[index - i].gain, 10) + diff;
+          }
+          if (eq[index + i] && eq[index + i].f) {
+            eq[index + i].gain = parseFloat(eq[index + i].gain, 10) + diff;
           }
         }
-
-        setAllEqSliders();
-
-        chart.prepareChart(eq);
       }
-
-      propagateData();
+      setAllEqSliders();
+      chart.prepareChart(eq);
     }
+    propagateData();
+  }
 
-		var propagateData = function() {
-			//send message
-				chrome.runtime.sendMessage({
-					action : 'set',
-					eq : eq,
-					config : config,
-					selected : presets.getSelected(),
-					version : version
-				});
-		};
+	var propagateData = function() {
+		//send message
+			chrome.runtime.sendMessage({
+				action : 'set',
+				eq : eq,
+				config : config,
+				selected : presets.getSelected(),
+				version : version
+			});
+	};
 
-		var inputs = document.querySelectorAll('input[type="range"]');
-		for (var i = 0; i < inputs.length; i++) {
-			inputs[i].onchange = onchange;
-			inputs[i].oninput = onchange;
+	var inputs = document.querySelectorAll('input[type="range"]');
+	for (var i = 0; i < inputs.length; i++) {
+		inputs[i].onchange = onchange;
+		inputs[i].oninput = onchange;
+	}
+
+	//TODO: dont repeat yor self!
+	document.getElementById('reset').onclick = function() {
+		for (var i = 0; i < eq.length; i++) {
+			if (eq[i].f) {
+				eq[i].gain = 0;
+			} else {
+				eq[i].gain = 1;
+			}
 		}
 
-		//TODO: dont repeat yor self!
-		document.getElementById('reset').onclick = function() {
-			for (var i = 0; i < eq.length; i++) {
-				if (eq[i].f) {
-					eq[i].gain = 0;
-				} else {
-					eq[i].gain = 1;
-				}
+    setAllEqSliders();
+
+		// When user presses reset, change it back to default value (stereo)
+		config.mono = false;
+		document.getElementById('channels').classList.remove('on');
+
+		presets.setSelected();
+
+		chart.prepareChart(eq);
+		propagateData();
+
+	};
+
+	document.getElementById('channels').onclick = function(ev) {
+		config.mono = !config.mono;
+		if (config.mono === true) {
+			document.getElementById('channels').classList.add('on');
+		} else {
+			document.getElementById('channels').classList.remove('on');
+		}
+		propagateData();
+	};
+
+	document.getElementById('snap').onclick = function(ev) {
+		config.snap = !config.snap;
+		if (config.snap === true) {
+			document.getElementById('snap').classList.add('on');
+		} else {
+			document.getElementById('snap').classList.remove('on');
+		}
+		propagateData();
+	};
+
+	document.getElementById('presets').onclick = function(ev) {
+
+		//load EQ presets
+		var userPresets = presets.getUsers();
+		var predefinedPresets = presets.getPredefined();
+		var selectedPreset = presets.getSelected();
+		console.log('userPresets', userPresets);
+		console.log('predefinedPresets', predefinedPresets);
+		console.log('selectedPreset', selectedPreset);
+		var userPresetsSelect = document.getElementById('presetsSelectUser');
+		var predefinedPresetsSelect = document.getElementById('presetsSelectPredefined');
+		userPresetsSelect.innerHTML = '';
+		if (selectedPreset.default === true) {
+			document.getElementById('preset_delete').setAttribute('disabled', 'disabled');
+		} else {
+			document.getElementById('preset_delete').removeAttribute('disabled');
+		}
+    var option, i;
+		for (i = 0; i < userPresets.length; i++) {
+			option = document.createElement("option");
+			option.text = userPresets[i].name;
+			option.setAttribute('value', 'preset::my::' + option.text);
+			if (presets.isSelected(userPresets[i])) {
+				option.setAttribute('selected', 'selected');
+			}
+			userPresetsSelect.appendChild(option, null);
+		}
+		predefinedPresetsSelect.innerHTML = '';
+		for (i = 0; i < predefinedPresets.length; i++) {
+			option = document.createElement("option");
+			option.text = predefinedPresets[i].name;
+			option.setAttribute('value', 'preset::default::' + option.text);
+			if (presets.isSelected(predefinedPresets[i])) {
+				option.setAttribute('selected', 'selected');
+			}
+			predefinedPresetsSelect.appendChild(option, null);
+		}
+
+		var mousedownEvent = document.createEvent("MouseEvent");
+		mousedownEvent.initMouseEvent("mousedown");
+		document.getElementById('presetsSelect').dispatchEvent(mousedownEvent);
+	};
+
+	document.getElementById('presetsSelect').onchange = function(ev) {
+		//console.log('ev.target', ev.target);
+		//console.log('val', ev.target.value);
+		var selected = presets.getSelected();
+		var updateEq = function() {
+			for (var i = 0; i < 10; i++) {
+				eq[i + 1].gain = selected.gains[i];
 			}
 
       setAllEqSliders();
 
-			// When user presses reset, change it back to default value (stereo)
-			config.mono = false;
-			document.getElementById('channels').classList.remove('on');
-
-			presets.setSelected();
-
 			chart.prepareChart(eq);
 			propagateData();
 
 		};
+		switch (ev.target.value) {
+		case 'action::save':
+			modal.confirm('Do you want to save "' + selected.name + '" preset?', function() {
+        for (var i = 0; i < selected.gains.length; i++)
+          selected.gains[i] = getValue('ch-eq-slider-' + (i + 1))
+				console.log('action::save', selected);
+				presets.setPreset(selected);
+				chrome.storage.sync.set({
+					presets : presets.getAll()
+				});
+			});
 
-		document.getElementById('channels').onclick = function(ev) {
-			config.mono = !config.mono;
-			if (config.mono === true) {
+			break;
+		case 'action::save_as':
+			modal.prompt('New preset name', function(name) {
+				if (name && name.length > 0) {
+					var preset = JSON.parse(JSON.stringify(selected));
+					preset.name = name;
+					presets.setNewPreset(preset);
+					chrome.storage.sync.set({
+						presets : presets.getAll()
+					});
+				}
+			}, function() {
+			});
+			break;
+		case 'action::delete':
+			modal.confirm('Do you want to delete "' + selected.name + '" preset?', function() {
+				presets.removeByName(selected.name);
+				chrome.storage.sync.set({
+					presets : presets.getAll()
+				});
+			});
+			break;
+		case 'action::reset':
+			modal.confirm('Do you want to reset "' + selected.name + '" preset?', function() {
+				presets.reset(selected.name);
+				presets.setSelected();
+				selected = presets.getSelected();
+				chrome.storage.sync.set({
+					presets : presets.getAll()
+				});
+				updateEq();
+			});
+
+			break;
+		case 'action::reset_all':
+			modal.confirm('Do you want to reset all presets to default state?', function() {
+				presets.resetAll();
+				presets.setSelected();
+				selected = presets.getSelected();
+				chrome.storage.sync.set({
+					presets : presets.getAll()
+				});
+				updateEq();
+			});
+			break;
+		default:
+			var val = (ev.target.value).split('::');
+			presets.setSelected(val[2]);
+			selected = presets.getSelected();
+			chrome.storage.local.set({
+				selected : selected.name
+			});
+			updateEq();
+		}
+
+	};
+
+	//intialization
+	chart.prepareChart(eq);
+	sliders.prepareSliders(eq);
+
+	if (chrome.runtime) {
+		chrome.runtime.sendMessage({
+			action : 'get'
+		}, function(response) {
+			eq = response.eq;
+			setAllEqSliders();
+
+			config = response.config;
+			// CUSTOM: make sure toggle is checked
+			if (config.mono) {
 				document.getElementById('channels').classList.add('on');
 			} else {
 				document.getElementById('channels').classList.remove('on');
 			}
-			propagateData();
-		};
-
-		document.getElementById('snap').onclick = function(ev) {
-			config.snap = !config.snap;
-			if (config.snap === true) {
+			if (config.snap) {
 				document.getElementById('snap').classList.add('on');
 			} else {
 				document.getElementById('snap').classList.remove('on');
 			}
-			propagateData();
-		};
-
-		document.getElementById('presets').onclick = function(ev) {
-
-			//load EQ presets
-			var userPresets = presets.getUsers();
-			var predefinedPresets = presets.getPredefined();
-			var selectedPreset = presets.getSelected();
-			console.log('userPresets', userPresets);
-			console.log('predefinedPresets', predefinedPresets);
-			console.log('selectedPreset', selectedPreset);
-			var userPresetsSelect = document.getElementById('presetsSelectUser');
-			var predefinedPresetsSelect = document.getElementById('presetsSelectPredefined');
-			userPresetsSelect.innerHTML = '';
-			if (selectedPreset.default === true) {
-				document.getElementById('preset_delete').setAttribute('disabled', 'disabled');
-			} else {
-				document.getElementById('preset_delete').removeAttribute('disabled');
-			}
-      var option, i;
-			for (i = 0; i < userPresets.length; i++) {
-				option = document.createElement("option");
-				option.text = userPresets[i].name;
-				option.setAttribute('value', 'preset::my::' + option.text);
-				if (presets.isSelected(userPresets[i])) {
-					option.setAttribute('selected', 'selected');
-				}
-				userPresetsSelect.appendChild(option, null);
-			}
-			predefinedPresetsSelect.innerHTML = '';
-			for (i = 0; i < predefinedPresets.length; i++) {
-				option = document.createElement("option");
-				option.text = predefinedPresets[i].name;
-				option.setAttribute('value', 'preset::default::' + option.text);
-				if (presets.isSelected(predefinedPresets[i])) {
-					option.setAttribute('selected', 'selected');
-				}
-				predefinedPresetsSelect.appendChild(option, null);
-			}
-
-			var mousedownEvent = document.createEvent("MouseEvent");
-			mousedownEvent.initMouseEvent("mousedown");
-			document.getElementById('presetsSelect').dispatchEvent(mousedownEvent);
-		};
-
-		document.getElementById('presetsSelect').onchange = function(ev) {
-			//console.log('ev.target', ev.target);
-			//console.log('val', ev.target.value);
-			var selected = presets.getSelected();
-			var updateEq = function() {
-				for (var i = 0; i < 10; i++) {
-					eq[i + 1].gain = selected.gains[i];
-				}
-
-        setAllEqSliders();
-
-				chart.prepareChart(eq);
-				propagateData();
-
-			};
-			switch (ev.target.value) {
-			case 'action::save':
-				modal.confirm('Do you want to save "' + selected.name + '" preset?', function() {
-          for (var i = 0; i < selected.gains.length; i++)
-            selected.gains[i] = getValue('ch-eq-slider-' + (i + 1))
-					console.log('action::save', selected);
-					presets.setPreset(selected);
-					chrome.storage.sync.set({
-						presets : presets.getAll()
-					});
-				});
-
-				break;
-			case 'action::save_as':
-				modal.prompt('New preset name', function(name) {
-					if (name && name.length > 0) {
-						var preset = JSON.parse(JSON.stringify(selected));
-						preset.name = name;
-						presets.setNewPreset(preset);
-						chrome.storage.sync.set({
-							presets : presets.getAll()
-						});
-					}
-				}, function() {
-				});
-				break;
-			case 'action::delete':
-				modal.confirm('Do you want to delete "' + selected.name + '" preset?', function() {
-					presets.removeByName(selected.name);
-					chrome.storage.sync.set({
-						presets : presets.getAll()
-					});
-				});
-				break;
-			case 'action::reset':
-				modal.confirm('Do you want to reset "' + selected.name + '" preset?', function() {
-					presets.reset(selected.name);
-					presets.setSelected();
-					selected = presets.getSelected();
-					chrome.storage.sync.set({
-						presets : presets.getAll()
-					});
-					updateEq();
-				});
-
-				break;
-			case 'action::reset_all':
-				modal.confirm('Do you want to reset all presets to default state?', function() {
-					presets.resetAll();
-					presets.setSelected();
-					selected = presets.getSelected();
-					chrome.storage.sync.set({
-						presets : presets.getAll()
-					});
-					updateEq();
-				});
-				break;
-			default:
-				var val = (ev.target.value).split('::');
-				presets.setSelected(val[2]);
-				selected = presets.getSelected();
-				chrome.storage.local.set({
-					selected : selected.name
-				});
-				updateEq();
-			}
-
-		};
-
-		//intialization
 			chart.prepareChart(eq);
-			sliders.prepareSliders(eq);
 
-			if (chrome.runtime) {
-				chrome.runtime.sendMessage({
-					action : 'get'
-				}, function(response) {
-					eq = response.eq;
-					setAllEqSliders();
-
-					config = response.config;
-					// CUSTOM: make sure toggle is checked
-					if (config.mono) {
-						document.getElementById('channels').classList.add('on');
-					} else {
-						document.getElementById('channels').classList.remove('on');
-					}
-					if (config.snap) {
-						document.getElementById('snap').classList.add('on');
-					} else {
-						document.getElementById('snap').classList.remove('on');
-					}
-					chart.prepareChart(eq);
-
-				});
-			}
+		});
+	}
 };
 
 //LOAD

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -69,13 +69,13 @@ var init = function(prs) {
 
 	var propagateData = function() {
 		//send message
-			chrome.runtime.sendMessage({
-				action : 'set',
-				eq : eq,
-				config : config,
-				selected : presets.getSelected(),
-				version : version
-			});
+		chrome.runtime.sendMessage({
+			action : 'set',
+			eq : eq,
+			config : config,
+			selected : presets.getSelected(),
+			version : version
+		});
 	};
 
 	var inputs = document.querySelectorAll('input[type="range"]');
@@ -95,13 +95,10 @@ var init = function(prs) {
 		}
 
     setAllEqSliders();
-
 		// When user presses reset, change it back to default value (stereo)
 		config.mono = false;
 		document.getElementById('channels').classList.remove('on');
-
 		presets.setSelected();
-
 		chart.prepareChart(eq);
 		propagateData();
 
@@ -133,9 +130,9 @@ var init = function(prs) {
 		var userPresets = presets.getUsers();
 		var predefinedPresets = presets.getPredefined();
 		var selectedPreset = presets.getSelected();
-		console.log('userPresets', userPresets);
-		console.log('predefinedPresets', predefinedPresets);
-		console.log('selectedPreset', selectedPreset);
+		// console.log('userPresets', userPresets);
+		// console.log('predefinedPresets', predefinedPresets);
+		// console.log('selectedPreset', selectedPreset);
 		var userPresetsSelect = document.getElementById('presetsSelectUser');
 		var predefinedPresetsSelect = document.getElementById('presetsSelectPredefined');
 		userPresetsSelect.innerHTML = '';
@@ -251,68 +248,59 @@ var init = function(prs) {
 			});
 			updateEq();
 		}
-
 	};
 
 	//intialization
 	chart.prepareChart(eq);
 	sliders.prepareSliders(eq);
 
-	if (chrome.runtime) {
-		chrome.runtime.sendMessage({
-			action : 'get'
-		}, function(response) {
-			eq = response.eq;
-			setAllEqSliders();
+	chrome.runtime.sendMessage({
+		action : 'get'
+	}, function(response) {
+		eq = response.eq;
+		setAllEqSliders();
 
-			config = response.config;
-			// CUSTOM: make sure toggle is checked
-			if (config.mono) {
-				document.getElementById('channels').classList.add('on');
-			} else {
-				document.getElementById('channels').classList.remove('on');
-			}
-			if (config.snap) {
-				document.getElementById('snap').classList.add('on');
-			} else {
-				document.getElementById('snap').classList.remove('on');
-			}
-			chart.prepareChart(eq);
+		config = response.config;
+		// CUSTOM: make sure toggle is checked
+		if (config.mono) {
+			document.getElementById('channels').classList.add('on');
+		} else {
+			document.getElementById('channels').classList.remove('on');
+		}
+		if (config.snap) {
+			document.getElementById('snap').classList.add('on');
+		} else {
+			document.getElementById('snap').classList.remove('on');
+		}
+		chart.prepareChart(eq);
 
-		});
-	}
+	});
 };
 
 //LOAD
 window.addEventListener("load", function() {
-	if (chrome && chrome.storage) {
-		chrome.storage.sync.get('presets', function(data) {
-			console.log('popup.js', 'presets', data);
-			if (data.presets) {
-				presets.setAll(data.presets);
-				chrome.storage.local.get('selected', function(data) {
-					console.log('popup.js', 'selected', data);
-					if (data.selected) {
-						presets.setSelected(data.selected.name);
-					}
-					init();
+	chrome.storage.sync.get('presets',
+    function(data) {
+  		// console.log('popup.js', 'presets', data);
+  		if (data.presets) {
+  			presets.setAll(data.presets);
+  			chrome.storage.local.get('selected', function(data) {
+  				// console.log('popup.js', 'selected', data);
+  				if (data.selected) {
+  					presets.setSelected(data.selected.name);
+  				}
+  			});
 
-				});
-
-			} else {
-				presets.setAll();
-				init();
-				//store it for next time
-				chrome.storage.sync.set({
-					presets : presets.getAll()
-				});
-			}
-		});
-	} else {
-		presets.setAll();
-		init();
-
-	}
+  		} else {
+  			presets.setAll();
+  			//store it for next time
+  			chrome.storage.sync.set({
+  				presets : presets.getAll()
+  			});
+  		}
+      init();
+  	}
+  );
 });
 
 // currently unsused


### PR DESCRIPTION
The chages aren't as massive as the diff makes them look, mostly just moved things around. All changes were only to popup.js, except adding a global I missed to the header comment on background.js. 

The globals comment is mainly for JsHint. It also adds clarity since you can see what's not local to the file, like import statements in other languages.

1. Put the updates to slider inputs into loops. Found one loop was used several times, so I put it in a function.

2. Removed the try/catch blocks. I analyzed them hard, and determined they were noise in the code with little-to-no real value. 

    As we discussed, we're already in a sandbox. All you were doing with any potential error is a `console.log` on the background page which isn't worth it. If something's misbehaving, just right click the popup and click Inspect Popup. The only risk is the extension doesn't work, which will probably happen anyways if there's an error.  

    Another major point to keep in mind is try/catch is completely synchronous. If you do something inside the block that has a callback, errors in the callback will not be caught. Same goes for event listeners. So it's probably not offering you the safety you think it is.

    I did save the message passing code as a function at the bottom. If later one of us wants to put any try/catch blocks back in, we can just do `try {...} catch(e) {forwardErrToBackground(e);}` to get that functionality back. 

3. Removed several `if (chrome...)` functionality tests. They aren't needed because we're inside an extension that only runs in chrome.

4. Renamed a few things and moved some things around for clarity. Abstracted a few bits of repeated code. Tried to pull a value off the current event target, allowing deletion of a function that loops over DOM elements (but that introduced a bug and I ultimately had to return the old code, we'll solve it later if doesn't get wiped away in the refactoring)

5. Did some more abstracting of duplicate code. Fixed the bugs I caused.

Things are pretty tightly coupled with presets.js in a way that's less than ideal. Presets unintuitively handles a lot more than than the presets. I'm going to dig into that next. I think I'll need to break things apart in a more drastic way. 

So far I'm just packing together similar actions and trimming fat so it's easier to follow what's going on. I'm finding there is state kept in too many different places, too many magical functions that "change something somewhere" and manage to lead to the right result. 

What I'm basically going to shoot for is 3 clear layers. One layer will respond to events with simple instructions ("this is what I want to do"), another layer will be functions to handle the logic of those instructions ("this is how I'm gonna do it"). Finally a layer at the bottom has the sole job of storing/retrieving state ("this is what I have done").

I want to do all this through only small commits that don't break anything. You might see some pull requests that look kind of ugly as things get reorganized.