### PR TITLE
remove setting target.id

### DIFF
--- a/extension/page/page.js
+++ b/extension/page/page.js
@@ -96,7 +96,6 @@ document.addEventListener("DOMContentLoaded", function onDocLoad() {
 							target.src = '' + target.src;
 						}
 						source = audioContext.createMediaElementSource(target);
-						target.setAttribute("id", 'test');
 						//console.dir(target);
 						//console.log(audioContext);
 						//console.log(filters);


### PR DESCRIPTION
Deleted a remnant of testing that is likely to cause regressions on many sites. If you change the id of the audio/video element, the main app can no longer access that element by its expected id.