### PR TITLE
Fix preset saving

### DIFF
--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -208,7 +208,6 @@ var init = function (prs) {
 					}
 				}, function () {
 				});
-
 				break;
 			case 'action::delete':
 				modal.confirm('Do you want to delete "' + selected.name + '" preset?', function () {

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -40,6 +40,12 @@ var init = function (prs) {
 		return false;
 	}
 
+	function savePresets(){
+		chrome.storage.sync.set({
+			presets: presets.getAll()
+		});
+	}
+
 	function loadPresets(){
 		//load EQ presets
 		if (presets.getSelected().default === true) {
@@ -184,6 +190,7 @@ var init = function (prs) {
 					}
 					console.log('action::save', selected);
 					presets.setPreset(selected);
+					savePresets();
 				});
 
 				break;
@@ -197,14 +204,16 @@ var init = function (prs) {
 						preset.name = name;
 						presets.setNewPreset(preset);
 						presets.setSelected(name);
-
+						savePresets();
 					}
 				}, function () {
 				});
+
 				break;
 			case 'action::delete':
 				modal.confirm('Do you want to delete "' + selected.name + '" preset?', function () {
 					presets.removeByName(selected.name);
+					savePresets();
 				});
 				break;
 			case 'action::reset':
@@ -213,6 +222,7 @@ var init = function (prs) {
 					presets.setSelected();
 					// setSelected calls getSelected internally, so no need calling again
 					updateEq();
+					savePresets();
 				});
 				break;
 			case 'action::reset_all':
@@ -220,6 +230,7 @@ var init = function (prs) {
 					presets.resetAll();
 					presets.setSelected();
 					updateEq();
+					savePresets();
 				});
 				break;
 			default:
@@ -231,10 +242,8 @@ var init = function (prs) {
 				});
 				updateEq();
 				loadPresets();
+				savePresets();
 		}
-		chrome.storage.sync.set({
-			presets: presets.getAll()
-		});
 	};
 
 	//intialization


### PR DESCRIPTION
Thanks for the great extension, I really enjoy it. I was also noticing the bug described in #48, but haven't really had a chance to dig into it until now. I found that unfortunately the call to `chrome.storage.sync.set` after the `switch` was getting called asynchronously before a particular case block was completed. This would effectively make it seem like nothing was being save/changed, because it the `set` was happening before the change took place.

This solution was the best one I came up with so far, and it seems to work. I'm happy to refactor it a different way if you would like, or implement any other suggestions you might have.