### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Audio EQ for Chrome
+# Audio EQ for Chrome
 
 With [Audio EQ for Chrome](https://chrome.google.com/webstore/detail/lfafdlnjaliaghpjdajmlcnnblkgcefh/) you can control your audio and video from all tabs in one place.
 More info [here](http://lab.ejci.net/Chrome-Audio-EQ/).
@@ -6,24 +6,24 @@ More info [here](http://lab.ejci.net/Chrome-Audio-EQ/).
 For best results install HTML5ify (https://chrome.google.com/webstore/detail/html5ify/jikbjpjgjmmdhcmlagappehlpiljoaop). 
 It will force popular sites to use HTML5 instead of Flash.
 
-###Disclaimer
+### Disclaimer
 This extension doesn't control Flash or Silverlight audio. It only controls HTML5 audio and video tags.
 It will not work on all pages. It works fine with Google Music, Youtube, Vimeo,...
 
-##How it works
+## How it works
 
 
 
-##Test videos
-###YouTube:
+## Test videos
+### YouTube:
 * [https://www.youtube.com/watch?v=nXOXXkx8rj0](https://www.youtube.com/watch?v=nXOXXkx8rj0)
 * [https://www.youtube.com/watch?v=PD-MdiUm1_Y](https://www.youtube.com/watch?v=PD-MdiUm1_Y)
 
-###Vimeo:
+### Vimeo:
 * [http://vimeo.com/watch](http://vimeo.com/watch)
 * [http://vimeo.com/11691174](http://vimeo.com/11691174)
 
-###HTML5 video:
+### HTML5 video:
 * [http://www.videojs.com/](http://www.videojs.com/)
 
 
@@ -32,5 +32,5 @@ Author: [Miroslav Magda](http://blog.ejci.net)
 Version: 0.3.3.1
 
 
-####License
+#### License
 All code is open source and dual licensed under GPL and MIT. Check the individual licenses for more information.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
